### PR TITLE
Add requirement to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Build Dependencies
 * [SKSE64](https://skse.silverlock.org/)
 * [CommonLibSSE](https://github.com/Ryan-rsm-McKenzie/CommonLibSSE)
+* [Json2Settings](https://github.com/Ryan-rsm-McKenzie/Json2Settings)
 
 ## End User Dependencies
 * [SKSE64](https://skse.silverlock.org/)


### PR DESCRIPTION
Added Json2Settings to build dependency in readme. I believe it is needed in order to properly build. :)